### PR TITLE
Migrate domain from wao.eco to wao.arweaveoasis.com

### DIFF
--- a/docs/docs/pages/book.mdx
+++ b/docs/docs/pages/book.mdx
@@ -581,4 +581,4 @@ Complete these tutorials in order. Each builds on concepts from the previous lev
 
 - [Official Documentation](https://hyperbeam.ar.io/)
 - [GitHub Repository](https://github.com/permaweb/HyperBEAM)
-- [Decoding HyperBEAM from Scratch](https://docs.wao.eco/hyperbeam/decoding-from-scratch)
+- [Decoding HyperBEAM from Scratch](https://docs.wao.arweaveoasis.com/hyperbeam/decoding-from-scratch)

--- a/docs/docs/pages/getting-started.mdx
+++ b/docs/docs/pages/getting-started.mdx
@@ -85,6 +85,6 @@ A lightweight edge implementation of the full AO network (AR, SU, MU, CU, BD) on
 
 ## Experiments
 Active experiments from the lab — usable but still evolving.
-- [AO in the Browser →](/web) — Full AO units running in your browser at [preview.wao.eco](https://preview.wao.eco)
+- [AO in the Browser →](/web) — Full AO units running in your browser at [preview.wao.arweaveoasis.com](https://preview.wao.arweaveoasis.com)
 - [HyperBEAM on Mobile →](/mobile) — Run a HyperBEAM node on Android / iOS
 - [Running LLMs on AOS →](/tutorials/running-llms) — Run AI models on AO processes

--- a/docs/docs/pages/web.mdx
+++ b/docs/docs/pages/web.mdx
@@ -8,6 +8,6 @@ WAO is both a standalone AO unit emulator and a lightweight SDK, enabling you to
 import { AO } from "wao/web"
 ```
 
-- [preview.wao.eco](http://preview.wao.eco)
+- [preview.wao.arweaveoasis.com](http://preview.wao.arweaveoasis.com)
 
 ![](/images/wao-web.png)

--- a/lp/src/components/Nav.jsx
+++ b/lp/src/components/Nav.jsx
@@ -46,7 +46,7 @@ export default function Nav() {
           </div>
 
           <div className={s.ctas}>
-            <a href="https://docs.wao.eco" className={s.docsBtn} target="_blank" rel="noopener noreferrer">Docs</a>
+            <a href="https://docs.wao.arweaveoasis.com" className={s.docsBtn} target="_blank" rel="noopener noreferrer">Docs</a>
             <a href="#get-started" className={s.startBtn} onClick={e => handleNav(e, 'get-started')}>
               Get Started
             </a>
@@ -69,7 +69,7 @@ export default function Nav() {
           </a>
         ))}
         <div className={s.mobileCtas}>
-          <a href="https://docs.wao.eco" className={s.docsBtn} target="_blank" rel="noopener noreferrer" onClick={closeMenu}>Docs</a>
+          <a href="https://docs.wao.arweaveoasis.com" className={s.docsBtn} target="_blank" rel="noopener noreferrer" onClick={closeMenu}>Docs</a>
           <a href="#get-started" className={s.startBtn} onClick={e => handleNav(e, 'get-started')}>
             Get Started
           </a>

--- a/lp/src/sections/Book.jsx
+++ b/lp/src/sections/Book.jsx
@@ -30,10 +30,10 @@ export default function Book() {
             </div>
           </div>
           <div className={s.btnRow}>
-            <a href="https://docs.wao.eco/book" className={`btn-primary ${s.ctaBtn}`} target="_blank" rel="noopener noreferrer">
+            <a href="https://docs.wao.arweaveoasis.com/book" className={`btn-primary ${s.ctaBtn}`} target="_blank" rel="noopener noreferrer">
               Read the Book
             </a>
-            <a href="https://docs.wao.eco/hyperbeam" className={`btn-ghost ${s.ctaBtn}`} target="_blank" rel="noopener noreferrer">
+            <a href="https://docs.wao.arweaveoasis.com/hyperbeam" className={`btn-ghost ${s.ctaBtn}`} target="_blank" rel="noopener noreferrer">
               Go to Reference
             </a>
           </div>

--- a/lp/src/sections/Browser.jsx
+++ b/lp/src/sections/Browser.jsx
@@ -35,7 +35,7 @@ export default function Browser() {
               <span className="browser-chrome-dot" />
               <span className="browser-chrome-dot" />
               <span className="browser-chrome-dot" />
-              <span className="browser-chrome-url">preview.wao.eco</span>
+              <span className="browser-chrome-url">preview.wao.arweaveoasis.com</span>
             </div>
             <img src="/images/wao-web.png" alt="WizardAO in the Browser" />
           </div>

--- a/lp/src/sections/Devnet.jsx
+++ b/lp/src/sections/Devnet.jsx
@@ -41,7 +41,7 @@ export default function Devnet() {
             </div>
           </div>
 
-          <a href="https://docs.wao.eco/devnet/overview" className={`btn-primary ${s.ctaBtn}`} target="_blank" rel="noopener noreferrer">
+          <a href="https://docs.wao.arweaveoasis.com/devnet/overview" className={`btn-primary ${s.ctaBtn}`} target="_blank" rel="noopener noreferrer">
             Try WAO DEVNET
           </a>
         </div>

--- a/lp/src/sections/GetStarted.jsx
+++ b/lp/src/sections/GetStarted.jsx
@@ -38,7 +38,7 @@ export default function GetStarted() {
         </div>
 
         <div className={s.ctas}>
-          <a href="https://docs.wao.eco" className="btn-primary" target="_blank" rel="noopener noreferrer">
+          <a href="https://docs.wao.arweaveoasis.com" className="btn-primary" target="_blank" rel="noopener noreferrer">
             Read the Docs
           </a>
           <a href="https://github.com/arweaveoasis/wao" className="btn-ghost" target="_blank" rel="noopener noreferrer">

--- a/lp/src/sections/HyperADD.jsx
+++ b/lp/src/sections/HyperADD.jsx
@@ -32,7 +32,7 @@ export default function HyperADD() {
             ))}
           </div>
 
-          <a href="https://docs.wao.eco/add/overview" className={`btn-primary ${s.ctaBtn}`} target="_blank" rel="noopener noreferrer">
+          <a href="https://docs.wao.arweaveoasis.com/add/overview" className={`btn-primary ${s.ctaBtn}`} target="_blank" rel="noopener noreferrer">
             Build with HyperADD
           </a>
         </div>

--- a/lp/src/sections/SDK.jsx
+++ b/lp/src/sections/SDK.jsx
@@ -60,7 +60,7 @@ export default function SDK() {
             ))}
           </div>
 
-          <a href="https://docs.wao.eco/api/overview" className="btn-primary" style={{ marginTop: '24px', width: 'fit-content' }} target="_blank" rel="noopener noreferrer">
+          <a href="https://docs.wao.arweaveoasis.com/api/overview" className="btn-primary" style={{ marginTop: '24px', width: 'fit-content' }} target="_blank" rel="noopener noreferrer">
             Explore the SDK
           </a>
         </div>


### PR DESCRIPTION
## Summary
- Update all `docs.wao.eco` links to `docs.wao.arweaveoasis.com`
- Update all `preview.wao.eco` links to `preview.wao.arweaveoasis.com`
- Covers both `lp/` (7 files) and `docs/` (3 files)