### PR TITLE
docs: align tutorials + hyperbeam pages with v0.9-FINAL

### DIFF
--- a/docs/docs/pages/add/build.mdx
+++ b/docs/docs/pages/add/build.mdx
@@ -257,7 +257,7 @@ When builds stall, run `/debug`. The wizard cross-references errors with the kno
 
 Common issues:
 - **Port conflicts** — stale HyperBEAM instances on the same port. `/test-hb` kills `beam.smp` automatically.
-- **WASM memory** — Node.js needs `--experimental-wasm-memory64` for AOS tests.
+- **WASM memory** — wasm-memory64 is default-on in Node 24+; for Node 22 set `NODE_OPTIONS=--experimental-wasm-memory64` before running AOS tests.
 - **Compile errors** — The Device Wizard reads rebar3 output and fixes Erlang issues automatically.
 
 ---

--- a/docs/docs/pages/hyperbeam/installing-hb-wao.md
+++ b/docs/docs/pages/hyperbeam/installing-hb-wao.md
@@ -33,7 +33,7 @@ Edit `package.json` to enable ESM and test commands, and disable concurrency so 
   },
   "dependencies": {
 	"hbsig": "^0.3.0",
-    "wao": "^0.40.0"
+    "wao": "^0.41.0"
   }
 }
 ```

--- a/docs/docs/pages/hyperbeam/legacynet-aos.md
+++ b/docs/docs/pages/hyperbeam/legacynet-aos.md
@@ -33,10 +33,11 @@ end)`
 describe("Processes and Scheduler", function () {
   let hbeam, hb
   before(async () => {
-    hbeam = await new HyperBEAM({ 
-	  reset: true, 
-	  as: ["genesis_wasm"]
-	}).ready()
+    hbeam = await new HyperBEAM({
+      reset: true,
+      genesis_wasm: true,
+      as: ["genesis_wasm"],
+    }).ready()
 	hb = hbeam.hb
   })
   after(async () => hbeam.kill())

--- a/docs/docs/pages/tutorials/custom-lua.mdx
+++ b/docs/docs/pages/tutorials/custom-lua.mdx
@@ -199,7 +199,7 @@ describe("Custom Lua on Local HB", function () {
 Run with:
 
 ```bash
-node --experimental-wasm-memory64 --test test/custom-lua.test.js
+node --test test/custom-lua.test.js
 ```
 
 ## Deploy to Arweave

--- a/docs/docs/pages/tutorials/hb.mdx
+++ b/docs/docs/pages/tutorials/hb.mdx
@@ -42,12 +42,12 @@ Make sure your `package.json` looks something like the following to enable ES6 a
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "test": "node --experimental-wasm-memory64 --test --test-concurrency=1",
-    "test-only": "node --experimental-wasm-memory64 --test-only --test-concurrency=1",
-    "test-all": "node --experimental-wasm-memory64 --test --test-concurrency=1 test/**/*.test.js"
+    "test": "node --test --test-concurrency=1",
+    "test-only": "node --test-only --test-concurrency=1",
+    "test-all": "node --test --test-concurrency=1 test/**/*.test.js"
   },
   "dependencies": {
-    "wao": "^0.40.0"
+    "wao": "^0.41.0"
   }
 }
 ```

--- a/docs/docs/pages/tutorials/hyperaos.mdx
+++ b/docs/docs/pages/tutorials/hyperaos.mdx
@@ -36,7 +36,7 @@ Make sure your `package.json` has the right test config:
 {
   "type": "module",
   "scripts": {
-    "test": "node --experimental-wasm-memory64 --test --test-concurrency=1"
+    "test": "node --test --test-concurrency=1"
   }
 }
 ```

--- a/docs/docs/pages/tutorials/legacynet.mdx
+++ b/docs/docs/pages/tutorials/legacynet.mdx
@@ -32,8 +32,8 @@ Add `test` and `test-only` commands to your `package.json`.
 ```json
 {
   "scripts": {
-    "test": "node --experimental-wasm-memory64",
-    "test-only": "node --experimental-wasm-memory64 --test-only"
+    "test": "node --test --test-concurrency=1",
+    "test-only": "node --test --test-only --test-concurrency=1"
   }
 }
 ```

--- a/docs/docs/pages/tutorials/rust-wasm64.mdx
+++ b/docs/docs/pages/tutorials/rust-wasm64.mdx
@@ -324,7 +324,7 @@ describe("Custom WASM64 on Local HB", function () {
 Run with:
 
 ```bash
-node --experimental-wasm-memory64 --test test/custom-wasm.test.js
+node --test test/custom-wasm.test.js
 ```
 
 ## Deploy to Arweave


### PR DESCRIPTION
## Summary
Align doc code samples with v0.9-FINAL behavior so a copy-paste from the
tutorials runs cleanly. Validated by the dhfs-tutorial-app sweep —
**41/41 tests pass in 155s** against a real local v0.9-FINAL HyperBEAM.

## Changes
- `docs/docs/pages/hyperbeam/installing-hb-wao.md`: wao dep `^0.40.0 → ^0.41.0`
- `docs/docs/pages/hyperbeam/legacynet-aos.md`: add `genesis_wasm: true` to
  the HyperBEAM constructor. Without it, the CU never spawns on :6363 and
  every `/{pid}/compute` call returns 400.
- `docs/docs/pages/tutorials/hb.mdx`: wao dep `^0.40.0 → ^0.41.0`
- `docs/docs/pages/tutorials/{custom-lua,rust-wasm64,hyperaos,legacynet}.mdx`:
  drop `--experimental-wasm-memory64` — Node 24+ rejects the flag
  (wasm-memory64 is default-on).
- `docs/docs/pages/add/build.mdx`: update the "WASM memory" note to
  describe the Node 22 vs 24+ split.

## Test plan
- [x] `dhfs-tutorial-app`: `npm test` → **41/41 pass in 155s**
- [x] All 12 chapter test files green: codec-flat, codec-httpsig,
  codec-structured, custom-devices-codecs, device-composition,
  devices-pathing, hashpaths, http-message-signatures, hyperbeam,
  legacynet-aos, payment-system, processes-scheduler

🤖 Generated with [Claude Code](https://claude.com/claude-code)