### PR TITLE
docs/tutorials: fix legacynet-aos genesis_wasm; audit confirms others OK

### DIFF
--- a/docs/docs/pages/tutorials/legacynet-aos.mdx
+++ b/docs/docs/pages/tutorials/legacynet-aos.mdx
@@ -32,6 +32,7 @@ describe("Hyperbeam Legacynet", function () {
     hbeam = await new HyperBEAM({
       cwd,
       reset: true,
+      genesis_wasm: true,
       as: ["genesis_wasm"],
     }).ready()
   })


### PR DESCRIPTION
## Summary
Final pass over `docs/docs/pages/tutorials/*.mdx` to confirm every tutorial
runs cleanly against v0.9-FINAL.

## Fix
- **`legacynet-aos.mdx`**: the first (raw-HTTP) variant passed only
  `as: ["genesis_wasm"]` (rebar3 build profile) without `genesis_wasm: true`
  (which actually spawns the CU on :6363). Without the spawn, every
  `/{pid}/compute` returned 400. The second variant in the same file
  already had `genesis_wasm: true`; this aligns the first.

## Audit confirmed OK
Walked every tutorial constructor:
- `custom-lua`, `rust-wasm64`, `devices-elixir`, `devices-gleam`,
  `creating-devices`, `hyperaos`: no genesis-wasm needed; `{ reset: true }`
- `mainnet-aos`, `hb`: wasm-64 path; `mode: "aos"` AO wrapper
- `hyperaos` (SDK variant): `mode: "lua"` AO wrapper
- `legacynet` (chapter): already has `{ reset: true, genesis_wasm: true }`
- `devices-cpp`, `devices-rust`: HyperBEAM source-tree tutorials, no HB ctor
- `running-llms`: in-memory `new AO()`, no HB

## Test plan
- [x] dhfs-tutorial-app sweep (12 chapter test files mirror the doc code):
      **41/41 pass in 155s** against real local v0.9-FINAL HB
- [x] grep audit: no remaining `experimental-wasm-memory64`, no
      `wao-beta3`, no `0.20./0.22./0.40.` version refs in tutorials

🤖 Generated with [Claude Code](https://claude.com/claude-code)