### PR TITLE
docs/api: align AO + HyperBEAM reference with v0.9-FINAL

### DIFF
--- a/docs/docs/pages/api/ao.mdx
+++ b/docs/docs/pages/api/ao.mdx
@@ -22,7 +22,8 @@ The `AO` constructor accepts the following options. You can also pass a port num
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `hb` | `"ans104"` \| `"httpsig"` \| `false` | `undefined` | Enable HyperBEAM mode with format |
+| `hb` | `string` \| `false` | `undefined` | Enable HyperBEAM mode. `"ans104"` / `"httpsig"` are format selectors (defaults to local HB URL); pass a full URL like `"https://push-1.forward.computer"` to target a remote node |
+| `mode` | `"legacy"` \| `"aos"` \| `"wasm"` \| `"lua"` | `"legacy"` when `hb` is set | Selects spawn/schedule/compute path: `legacy` → genesis-wasm CU; `aos`/`wasm` → wasm-64; `lua` → hyper-aos `lua@5.3a` |
 | `module` | `string` | auto by `module_type` | Module ID |
 | `module_type` | `"aos2"` \| `"sqlite"` \| `"mainnet"` | `"aos2"` | Selects default module |
 | `scheduler` | `string` | built-in default | Scheduler address |

--- a/docs/docs/pages/api/hyperbeam.mdx
+++ b/docs/docs/pages/api/hyperbeam.mdx
@@ -13,22 +13,23 @@ import { describe, it, before, after } from "node:test"
 describe("HyperBEAM", function () {
   let hbeam
   before(async () => {
-	hbeam = await new HyperBEAM({ 
+    hbeam = await new HyperBEAM({
       port: 10001,
-	  wallet: ".wallet.json",
-      cwd: "./HyperBEAM", 
+      wallet: ".wallet.json",
+      cwd: "./HyperBEAM",
       reset: true,
-	  bundler: 4001,
-	  gateway: 4000,
-	  logs: true,
-	  shell: true,
-	  as: [ "genesis_wasm" ],
-	  devices: [ "flat", "structured", "httpsig", "json", "meta" ],
-	  faff: [ addr, addr2, addr3 ],
-	  simple_pay: true,
-	  simple_pay_price: 3,
-	  p4_lua: { processor: pid, client: cid },
-	  operator: addr
+      bundler: 4001,
+      gateway: 4000,
+      logs: true,
+      shell: true,
+      as: ["genesis_wasm"],
+      genesis_wasm: true,
+      devices: ["flat", "structured", "httpsig", "json", "meta"],
+      faff: [addr, addr2, addr3],
+      simple_pay: true,
+      simple_pay_price: 3,
+      p4_lua: { processor: pid, client: cid },
+      operator: addr,
     }).ready()
   })
   after(() => hbeam.kill())
@@ -53,7 +54,7 @@ hbeam.kill()
 | `gateway` | - | gateway service port |
 | `logs` | `true` | set `false` to disable HyperBEAM logs |
 | `shell` | `true` | `false` to not auto-start `rebar3 shell` |
-| `rebar3` | `true` | use `rebar3 shell` (`true`) or direct `erl` (`false`) |
+| `rebar3` | `true` | use `rebar3 shell` (`true`) or direct `erl` (`false`); honors `HB_REBAR3` env |
 | `as` | `[]` | `rocksdb`, `genesis_wasm`, `http3` |
 | `devices` | - | array of preloaded devices, `undefined` to load everything |
 | `faff` | - | array of addresses (likely for funding/faucet) |
@@ -64,9 +65,11 @@ hbeam.kill()
 | `genesis_wasm` | `false` | start a genesis-wasm CU alongside HyperBEAM |
 | `arweave_gateway` | - | custom Arweave gateway URL (e.g. Cloudflare proxy) |
 | `force_signed` | `false` | require signed requests |
+| `linkify_mode` | (HB default) | v0.9-FINAL HB `linkify-mode` option; pass `false` for hbsig-style inline-only responses (lets cache reads stay in the same multipart body instead of being relinked) |
 | `store_prefix` | - | custom store prefix (randomized if set) |
 | `bundler_ans104` | - | ANS-104 bundler port |
 | `bundler_httpsig` | - | HTTPSig bundler URL |
+| `p4_non_chargable_routes` | - | list of route patterns the p4 device should skip charging on |
 | `c` | - | GCC version for compilation (sets CC/CXX) |
 | `cmake` | - | CMAKE_POLICY_VERSION_MINIMUM value |
 
@@ -129,6 +132,19 @@ CMAKE_POLICY_VERSION_MINIMUM=3.5
 | `ans104` | `ans104@1.0` | `dev_codec_ans104` |
 | `cacheviz` | `cacheviz@1.0` | `dev_cacheviz` |
 | `wao` | `wao@1.0` | `dev_wao` |
+| `metering` | `metering@1.0` | `dev_metering` (v0.9-FINAL) |
+| `location` | `location@1.0` | `dev_location` (v0.9-FINAL) |
+| `trie` | `trie@1.0` | `dev_trie` (v0.9-FINAL) |
+| `blacklist` | `blacklist@1.0` | `dev_blacklist` (v0.9-FINAL) |
+| `rate-limit` | `rate-limit@1.0` | `dev_rate_limit` (v0.9-FINAL) |
+| `secret` | `secret@1.0` | `dev_secret` (v0.9-FINAL) |
+| `copycat` | `copycat@1.0` | `dev_copycat` (v0.9-FINAL) |
+| `arweave` | `arweave@2.9` | `dev_arweave` (v0.9-FINAL) |
+| `b32-name` | `b32-name@1.0` | `dev_b32_name` (v0.9-FINAL) |
+| `bundler` | `bundler@1.0` | `dev_bundler` (v0.9-FINAL) |
+| `gzip` | `gzip@1.0` | `dev_gzip` (v0.9-FINAL) |
+| `tx` | `tx@1.0` | `dev_codec_tx` (v0.9-FINAL) |
+| `whois` | `whois@1.0` | `dev_whois` (v0.9-FINAL) |
 
 If the device is not listed, you need to define it yourself.
 


### PR DESCRIPTION
## Summary
Walk `docs/docs/pages/api/*.mdx` and align it with the v0.9-FINAL surface.

## Changes

### `api/ao.mdx`
- `hb` option: now also accepts a URL string (e.g. \`\"https://push-1.forward.computer\"\`) to target a remote HyperBEAM node, in addition to \`\"ans104\"\`/\`\"httpsig\"\` format selectors. Updated type + description.
- Document the \`mode\` option (\`\"legacy\"\`/\`\"aos\"\`/\`\"wasm\"\`/\`\"lua\"\`) which selects the spawn/schedule/compute path.

### `api/hyperbeam.mdx`
- Add \`genesis_wasm: true\` to the example constructor so copy-paste actually spawns the CU on :6363. The \`as: [\"genesis_wasm\"]\` rebar3 build profile alone isn't enough — without \`genesis_wasm: true\` the CU never starts and every \`/{pid}/compute\` returns 400.
- Document the v0.9-FINAL \`linkify_mode\` constructor option (used by hbsig-style inline-only response mode).
- Document \`p4_non_chargable_routes\` and \`rebar3\` (with \`HB_REBAR3\` env hint).
- Add 13 new v0.9-FINAL preloaded devices to the table: \`metering\`, \`location\`, \`trie\`, \`blacklist\`, \`rate-limit\`, \`secret\`, \`copycat\`, \`arweave\` (\`arweave@2.9\`), \`b32-name\`, \`bundler\`, \`gzip\`, \`tx\`, \`whois\`.

### Audit OK (no changes needed)
- `api/hb.mdx`: methods (spawn/schedule/compute + Legacy + AOS + Lua variants, pushAOS, messageAOS) all documented
- `api/hbsig.mdx`, `api/armem.mdx`, `api/gql.mdx`, `api/ar.mdx`, `api/process.mdx`, `api/function-piping.mdx`, `api/overview.mdx`: already current; no outdated patterns

## Test plan
- [x] dhfs-tutorial-app sweep still 41/41 (validates the API surface the docs describe)
- [x] grep audit: no remaining outdated version refs in `docs/docs/pages/api/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)