### PR TITLE
docs/api: audit src/ + hbsig/, fill gaps (Adaptor, ArMem fields, HyperBEAM fields)

### DIFF
--- a/docs/docs/pages/api/adaptor.mdx
+++ b/docs/docs/pages/api/adaptor.mdx
@@ -1,0 +1,100 @@
+# Adaptor
+
+`Adaptor` is the bridge that lets a browser-side WAO IDE (e.g. WAO Studio) expose its in-memory `ArMem` state over HTTP / WebSocket so that an external HyperBEAM node, a remote Wander client, or another peer can hit the same MU / SU / CU endpoints they'd hit on a real network.
+
+It runs inside the page (`wao/web`) or inside a Cloudflare worker (`wao/cf`) and translates incoming HTTP-shaped requests into calls against the same `aoconnect`-bound `mem`, `message`, `spawn`, `dryrun`, `result`, etc. that the AO class uses internally.
+
+## Instantiate
+
+```js
+import { AO, Adaptor } from "wao/web"
+
+const ao = await new AO({ variant: "ao.TN.1" }).init(acc[0])
+await ao.mem.init()
+
+const adaptor = new Adaptor({
+  hb_url: "http://localhost:10001",
+  aoconnect: ao.mem,
+})
+```
+
+## Constructor Options
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `hb_url` | `string` | - | HyperBEAM node URL. When set, the Adaptor wires an [HB](/api/hb) client into the underlying `connect()`. |
+| `aoconnect` | `ArMem` \| `object` | - | The in-memory `ArMem` instance (`ao.mem`) or a Wander aoconnect config. The Adaptor delegates message / spawn / dryrun calls to this backend. |
+| `log` | `boolean` \| `"none"` \| `"info"` \| `"debug"` | `false` | Forwarded to the internal `connect()` call. |
+| `db` | `object` | - | Optional KV-style storage backend (e.g. Cloudflare D1, IndexedDB wrapper). |
+| `storage` | `object` | - | Optional blob storage backend. |
+| `connect` | `function` | wao's built-in | Override the `connect()` implementation (rare). |
+| `GQL` | `class` | wao's built-in | Override the GQL class used for queries (rare). |
+| `cu` / `su` / `mu` | `signer` | - | Wallet signers for CU / SU / MU endpoints. |
+| `d1` / `r2` / `kv` | object | - | Cloudflare Workers bindings (used by `wao/cf`). |
+| `network` | `string` | `"ao.DN.1"` | Variant identifier ("ao.TN.1" or "ao.DN.1"). |
+
+## get
+
+The primary entry point. Dispatches a request to the appropriate handler based on `req.device`:
+
+- `bd` → bundler (data items)
+- `ar` → Arweave gateway (transactions, GraphQL)
+- `su` → Scheduler Unit
+- `mu` → Message Unit
+- `cu` → Compute Unit
+
+```js
+await adaptor.get(req, res => {
+  // res handler is called with the response payload
+})
+```
+
+## Per-device entry points
+
+Each device method dispatches by HTTP method (`req.method`):
+
+```js
+await adaptor.bd(req)   // bundler: bd_get / bd_post / bd_post_tx
+await adaptor.ar(req)   // Arweave: ar_get / ar_post
+await adaptor.su(req)   // SU: su_get / su_post
+await adaptor.mu(req)   // MU: mu_get / mu_delete / mu_post
+await adaptor.cu(req)   // CU: cu_get / cu_post
+```
+
+## Underlying Wander Methods
+
+The Adaptor stores the `connect()` bindings so you can drive raw aoconnect-compatible calls directly:
+
+```js
+adaptor.spawn(...)
+adaptor.message(...)
+adaptor.result(...)
+adaptor.dryrun(...)
+adaptor.monitor(...)
+adaptor.recover(processId)
+adaptor.evaluate(...)
+```
+
+## `adaptor.mem` and `adaptor.gql`
+
+`adaptor.mem` is the same `ArMem` instance used by `aoconnect`. `adaptor.gql` is a `GQL` instance backed by `mem` (or `d1` when on Cloudflare).
+
+## Typical Setup with a Hub
+
+In WAO Studio the Adaptor is wired up alongside a `Hub` WebSocket client so a remote HyperBEAM (or peer) can talk to the in-browser AO:
+
+```js
+import { Adaptor } from "wao/web"
+import Hub from "/lib/hub"
+
+const adaptor = new Adaptor({ hb_url, aoconnect: g.ao.mem })
+const hub = new Hub("ws://localhost:7777")
+hub.onMsg = async obj => {
+  adaptor.get(obj.req, res => {
+    hub.socket.send(JSON.stringify({ id: obj.id, res }))
+  })
+}
+hub.connect()
+```
+
+See the [WAO Studio source](https://github.com/weavedb/wao/tree/master/app) for a full integration.

--- a/docs/docs/pages/api/armem.mdx
+++ b/docs/docs/pages/api/armem.mdx
@@ -48,3 +48,21 @@ const ao2 = new AO({ mem: ao.mem })
 ```
 
 This will connect the two.
+
+## State Inspection
+
+The `ArMem` instance exposes the in-memory state as plain object maps. These are read-only from a consumer's perspective and useful for introspecting what's been deployed/messaged during a test.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `mem.env` | `{ [pid: string]: ProcessState }` | All spawned processes by pid. Each entry carries the AOS module handle, memory snapshot, message results history, etc. |
+| `mem.msgs` | `{ [mid: string]: MessageRecord }` | All scheduled messages by message id, with the compute result and the original signed message item. |
+| `mem.txs` | `{ [txid: string]: TxRecord }` | All Arweave transactions: module wasm uploads, process spawns, messages, data items. Each has `id`, `block`, `owner`, `tags`. |
+| `mem.modules` | `{ [name: string]: txid }` | Map of named module wasm IDs (e.g. `"aos2_0_4_32"` → its tx id). |
+| `mem.wasms` | `{ [txid: string]: { file, format, variant? } }` | Reverse map: wasm tx id → file name + module format. |
+| `mem.blockmap` | `{ [height: number]: BlockRecord }` | Block records by height. |
+| `mem.addrmap` | `{ [scheduler: string]: { address } }` | Scheduler-address aliases. |
+| `mem.modmap` | `{ [txid: string]: name }` | Reverse of `mem.modules`. |
+| `mem.height` | `number` | Current Arweave block height counter (advances per write). |
+
+`mem.init()` (auto-called when AO is constructed in-memory) seeds the default modules + scheduler so a freshly-instantiated AO has functioning module / scheduler txs.

--- a/docs/docs/pages/api/hyperbeam.mdx
+++ b/docs/docs/pages/api/hyperbeam.mdx
@@ -41,6 +41,21 @@ describe("HyperBEAM", function () {
 hbeam.kill()
 ```
 
+## Instance Fields
+
+After `.ready()`, the `HyperBEAM` instance exposes:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `hbeam.hb` | `HB` | Initialized [HB](/api/hb) client targeting the spawned node. Use this for most interactions. |
+| `hbeam.url` | `string` | `http://127.0.0.1:<port>` — the node URL. |
+| `hbeam.jwk` | `JWK` | Operator wallet JWK loaded from `wallet_location`. |
+| `hbeam.addr` | `string` | Operator wallet address (derived from `jwk.n`). |
+| `hbeam.operator` | `string` | Operator address from the `operator` option (defaults to `addr`). `HyperBEAM.OPERATOR` is resolved to `addr` automatically. |
+| `hbeam.cuProc` | `ChildProcess` | Genesis-wasm CU child process handle when `genesis_wasm: true`. |
+| `hbeam.dirname` | `string` | Resolved absolute path of the HyperBEAM source tree (`cwd`). |
+| `hbeam.wallet_location` | `string` | Resolved absolute path of the wallet JWK. |
+
 ## Parameters
 
 | Name | Default | Description |

--- a/docs/docs/pages/api/overview.mdx
+++ b/docs/docs/pages/api/overview.mdx
@@ -19,3 +19,4 @@ npm install wao
 | [HB](/api/hb) | HyperBEAM node management |
 | [HyperBEAM](/api/hyperbeam) | HyperBEAM SDK utilities |
 | [HBSig](/api/hbsig) | HyperBEAM HTTP message signatures |
+| [Adaptor](/api/adaptor) | Bridge a browser-side ArMem to external HyperBEAM / Wander peers over HTTP / WebSocket |

--- a/docs/vocs.config.ts
+++ b/docs/vocs.config.ts
@@ -422,6 +422,10 @@ export default defineConfig({
           text: "HBSig",
           link: "/api/hbsig",
         },
+        {
+          text: "Adaptor",
+          link: "/api/adaptor",
+        },
       ],
     },
     {


### PR DESCRIPTION
## Summary
Walked every file under \`src/\` and \`hbsig/src/\` and cross-checked the public surface against \`docs/docs/pages/api/\`.

**Existing coverage is complete** for AO, AR, HB, GQL, HyperBEAM (constructor), Process, Function Piping, HBSig, ArMem (intro). Method-by-method audit:

| Class | Source methods | Doc coverage |
|-------|----------------|---------------|
| AO | init, spwn, msg, dry, res, ress, asgn, eval, transform, load, wait, attest, avail, deploy, var, postModule, postScheduler, p, pipe | ✓ all in ao.mdx + function-piping.mdx |
| Process | load, msg, dry, res, m, d, v, r, o | ✓ all in process.mdx |
| AR | init, mine, checkWallet, balance, mint, toWinston, toAR, toAddr, gen, transfer, bundle, post, postTx, tx, data, isArConnect | ✓ all in ar.mdx |
| HB | constructor + 41 async methods (spawn/schedule/compute + Legacy/AOS/Lua variants, pushAOS, messageAOS, post104, send104, …) | ✓ all in hb.mdx |
| GQL | txs, blocks, fetch | ✓ all in gql.mdx |
| HBSig | id, hashpath, rsaid, hmacid, base, toAddr, sign, signer, createSigner, send, commit, result, verify, extractPubKey, decodeSigInput, normalize, erl_json_to/from, erl_str_to/from, structured_to/from, httpsig_to/from, flat_to/from | ✓ all in hbsig.mdx |
| HyperBEAM | constructor, ready, kill, eunit, file (+internal: shell/startCU/ok/genEnv/genEval) | ✓ all in hyperbeam.mdx |

## Three gaps closed

### 1. ArMem state-inspection fields (\`armem.mdx\`)
The browser-side IDE (WAO Studio) and many tests read directly from \`ao.mem.{env, msgs, txs, modules, wasms, blockmap, addrmap, modmap, height}\`. These were public-but-undocumented; added a "State Inspection" table describing each field's shape.

### 2. HyperBEAM instance fields (\`hyperbeam.mdx\`)
After \`.ready()\` the \`HyperBEAM\` instance exposes \`hb\`, \`url\`, \`jwk\`, \`addr\`, \`operator\`, \`cuProc\`, \`dirname\`, \`wallet_location\`. These are the actual handles every test reaches for (\`hbeam.hb\`, \`hbeam.jwk\`, etc.); now documented in an "Instance Fields" table.

### 3. Adaptor (new page: \`api/adaptor.mdx\`)
The \`Adaptor\` class is exported from \`wao/test\`, \`wao/web\`, \`wao/cf\` and used by WAO Studio's ProxyModal / FSModal to bridge a browser-side ArMem to external HyperBEAM / Wander peers — but had no doc page. Added a full reference:
- Constructor options table (\`hb_url\`, \`aoconnect\`, \`log\`, \`db\`/\`storage\`, \`cu\`/\`su\`/\`mu\` signers, \`d1\`/\`r2\`/\`kv\` Cloudflare bindings, \`network\`)
- \`get(req, res)\` entry point + per-device dispatch (bd/ar/su/mu/cu)
- Underlying Wander methods (spawn/message/result/dryrun/monitor/recover/evaluate)
- \`adaptor.mem\` + \`adaptor.gql\` accessors
- Typical Hub WebSocket integration pattern
- Added to \`overview.mdx\` + the \`vocs.config.ts\` sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)