### PR TITLE
src/workspace + dhfs verification: bump bundled template to wao 0.41.1 / hbsig 0.3.1

### DIFF
--- a/src/workspace/package.json
+++ b/src/workspace/package.json
@@ -12,7 +12,7 @@
     "deploy": "node scripts/deploy.js"
   },
   "dependencies": {
-    "hbsig": "0.3.0",
-    "wao": "0.40.2"
+    "hbsig": "0.3.1",
+    "wao": "0.41.1"
   }
 }


### PR DESCRIPTION
## Summary
Bump the bundled workspace template + re-verify the dhfs tutorial sweep.

\`src/workspace/package.json\` ships inside the wao npm package and is what
Claude Code / the build skills scaffold from. It was still pinned at
\`wao 0.40.2\` + \`hbsig 0.3.0\` — pre-v0.9-FINAL.

- \`wao\` 0.40.2 → 0.41.1
- \`hbsig\` 0.3.0 → 0.3.1

## Test plan
- [x] \`dhfs-tutorial-app\` sweep against real local v0.9-FINAL HyperBEAM:
  **41/41 pass in 144s** (12 chapter test files: codec-flat, codec-httpsig,
  codec-structured, custom-devices-codecs, device-composition, devices-
  pathing, hashpaths, http-message-signatures, hyperbeam, legacynet-aos,
  payment-system, processes-scheduler).
- [x] grep audit: no remaining outdated \`wao\` or \`hbsig\` version pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)